### PR TITLE
fix: avoid side effects in course stats

### DIFF
--- a/src/app/courses/[id]/CTASection.tsx
+++ b/src/app/courses/[id]/CTASection.tsx
@@ -158,9 +158,9 @@ export default function CTASection({ course }: CTASectionProps) {
                 <div className="p-8 w-full">
                   <div className="grid grid-cols-3 gap-6 text-center">
                     <div>
-                      <div className="text-2xl font-bold text-white">{
-                        course.studentCountFormatted = course.studentCount.toLocaleString('id-ID')
-}</div>
+                      <div className="text-2xl font-bold text-white">
+                        {course.studentCount.toLocaleString('id-ID')}
+                      </div>
                       <div className="text-sm text-gray-200">Students</div>
                     </div>
                     <div>

--- a/src/app/courses/[id]/CourseHero.tsx
+++ b/src/app/courses/[id]/CourseHero.tsx
@@ -18,6 +18,8 @@ interface CourseHeroProps {
 
 export default function CourseHero({ course }: CourseHeroProps) {
   const [isWishlisted, setIsWishlisted] = useState(false);
+  const reviewCountFormatted = course.reviewCount.toLocaleString('id-ID');
+  const studentCountFormatted = course.studentCount.toLocaleString('id-ID');
 
   return (
     <section className="relative py-16 px-6 md:px-12 lg:px-16 overflow-hidden">
@@ -71,15 +73,13 @@ export default function CourseHero({ course }: CourseHeroProps) {
               <div className="flex items-center gap-2">
                 <Rating value={course.rating} precision={0.1} size="small" readOnly />
                 <span className="text-sm font-semibold text-gray-900">{course.rating}</span>
-                <span className="text-sm text-slate-600">({course.reviewCountFormatted = course.reviewCount.toLocaleString('id-ID')
-                } reviews)</span>
+                <span className="text-sm text-slate-600">({reviewCountFormatted} reviews)</span>
               </div>
               <div className="flex items-center gap-1 text-slate-600">
                 <div className="w-4 h-4 flex items-center justify-center">
                   <i className="ri-user-line text-sm"></i>
                 </div>
-                <span className="text-sm">{
-                  course.studentCountFormatted = course.studentCount.toLocaleString('id-ID')} students</span>
+                <span className="text-sm">{studentCountFormatted} students</span>
               </div>
               <div className="flex items-center gap-1 text-slate-600">
                 <div className="w-4 h-4 flex items-center justify-center">

--- a/src/app/courses/[id]/InstructorSection.tsx
+++ b/src/app/courses/[id]/InstructorSection.tsx
@@ -9,6 +9,7 @@ interface InstructorSectionProps {
 }
 
 export default function InstructorSection({ instructor }: InstructorSectionProps) {
+  const studentsFormatted = instructor.students.toLocaleString('id-ID');
   return (
     <section className="py-16 px-6 md:px-12 lg:px-16 bg-gradient-to-br from-purple-50 via-white to-pink-50">
       <div className="max-w-7xl mx-auto">
@@ -68,7 +69,7 @@ export default function InstructorSection({ instructor }: InstructorSectionProps
                 <div className="flex items-center gap-3 mb-6">
                   <Rating value={instructor.rating} precision={0.1} size="small" readOnly />
                   <span className="font-semibold text-gray-900">{instructor.rating}</span>
-                  <span className="text-slate-600">({instructor.studentsFormatted = instructor.students.toLocaleString('id-ID')} students)</span>
+                  <span className="text-slate-600">({studentsFormatted} students)</span>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- avoid mutation in course stats formatting
- show formatted student count without side effects

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: `'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`. react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_68973a9335ec8327bcb4c4408ec933c2