### PR TITLE
feat(payment): print invoice section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "next-auth": "^4.24.11",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-to-print": "^3.1.1",
         "recharts": "^3.1.2",
         "remixicon": "^4.6.0"
       },
@@ -6517,6 +6518,15 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-to-print": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-3.1.1.tgz",
+      "integrity": "sha512-N0MUMhpl8nkGri13BjP7zusj3B/j+1eMOTt8N8PYuhBYGzA4PqTXqcihJ9cZw996dvhV6mBdwafIQCg3Ap5bKg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ~19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next-auth": "^4.24.11",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-to-print": "^3.1.1",
     "recharts": "^3.1.2",
     "remixicon": "^4.6.0"
   },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,3 +23,9 @@ body {
   color: var(--color-foreground);
   font-family: var(--font-sans);
 }
+
+@media print {
+  .no-print {
+    display: none !important;
+  }
+}

--- a/src/app/payment/page.tsx
+++ b/src/app/payment/page.tsx
@@ -1,7 +1,8 @@
 
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
 import {
   Card,
   CardContent,
@@ -30,6 +31,8 @@ export default function PaymentPage() {
   const [loading, setLoading] = useState(false);
   const [paymentStep, setPaymentStep] = useState('select'); // select, processing, success
   const [qrCodeGenerated, setQrCodeGenerated] = useState(false);
+  const invoiceRef = useRef<HTMLDivElement>(null);
+  const handlePrint = useReactToPrint({ content: () => invoiceRef.current });
 
   const orderData = {
     planTitle: "Japanese N5 Mastery – 1 Month Access",
@@ -101,7 +104,7 @@ export default function PaymentPage() {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-50 py-12 px-4">
         <div className="max-w-md mx-auto">
-          <Card className="rounded-2xl shadow-lg">
+          <Card ref={invoiceRef} className="rounded-2xl shadow-lg">
             <CardContent className="p-0">
               {/* Header */}
               <div className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white p-6 rounded-t-2xl">
@@ -214,7 +217,7 @@ export default function PaymentPage() {
                 </div>
 
                 {/* Action Buttons */}
-                <div className="space-y-3">
+                <div className="space-y-3 no-print">
                   <Button
                     variant="contained"
                     fullWidth
@@ -228,7 +231,7 @@ export default function PaymentPage() {
                     variant="outlined"
                     fullWidth
                     className="border-gray-300 text-gray-700 hover:bg-gray-50 py-3 rounded-xl"
-                    onClick={() => window.print()}
+                    onClick={handlePrint}
                   >
                     Print Invoice
                   </Button>


### PR DESCRIPTION
## Summary
- allow printing only the invoice card on payment success using react-to-print
- hide non-print elements with a `no-print` utility style

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: see output for errors)*

------
https://chatgpt.com/codex/tasks/task_e_68974692bee0832799fb8e6dcb0353a7