### PR TITLE
refactor: isolate node deps from edge runtime

### DIFF
--- a/src/auth-edge.ts
+++ b/src/auth-edge.ts
@@ -1,0 +1,6 @@
+import NextAuth from "next-auth";
+
+export const { auth } = NextAuth({
+  session: { strategy: "jwt" },
+  providers: [],
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,1 @@
-export { auth as middleware } from "@/auth";
+export { auth as middleware } from "@/auth-edge";


### PR DESCRIPTION
## Summary
- move credential auth logic to server-side only and switch to JWT sessions
- add edge-safe auth instance and wire middleware to it

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: react/no-unescaped-entities, @typescript-eslint/no-unused-vars, etc.)
- `NEXT_IGNORE_ESLINT=1 npm run build` (fails: react/no-unescaped-entities, @typescript-eslint/no-unused-vars, etc.)

------
https://chatgpt.com/codex/tasks/task_e_689761bf9e14832784022fece7beb956